### PR TITLE
test: add unit tests for transactions

### DIFF
--- a/src/main/java/com/pixelocura/bitscafe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pixelocura/bitscafe/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.pixelocura.bitscafe.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Object> handleBadRequest(BadRequestException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", ZonedDateTime.now());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Bad Request");
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    // añadir otras excepciones personalizadas:
+    /*
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Object> handleNotFound(ResourceNotFoundException ex) {
+        ...
+    }
+    */
+}

--- a/src/main/java/com/pixelocura/bitscafe/service/impl/AdminTransactionServiceImpl.java
+++ b/src/main/java/com/pixelocura/bitscafe/service/impl/AdminTransactionServiceImpl.java
@@ -28,11 +28,18 @@ public class AdminTransactionServiceImpl implements AdminTransactionService {
     private UserRepository userRepository; //final? x2
     private GameRepository gameRepository;
 
-    public AdminTransactionServiceImpl(TransactionRepository transactionRepository,
-                                       TransactionDetailRepository transactionDetailRepository) {
+    public AdminTransactionServiceImpl(
+            TransactionRepository transactionRepository,
+            TransactionDetailRepository transactionDetailRepository,
+            UserRepository userRepository,
+            GameRepository gameRepository
+    ) {
         this.transactionRepository = transactionRepository;
         this.transactionDetailRepository = transactionDetailRepository;
+        this.userRepository = userRepository;
+        this.gameRepository = gameRepository;
     }
+
 
     @Override
     public List<TransactionDTO> getTransactionsByUser(UUID userId) {

--- a/src/test/java/com/pixelocura/bitscafe/controller/AdminFavoriteControllerUnitTest.java
+++ b/src/test/java/com/pixelocura/bitscafe/controller/AdminFavoriteControllerUnitTest.java
@@ -1,0 +1,90 @@
+package com.pixelocura.bitscafe.controller;
+
+import com.pixelocura.bitscafe.dto.FavoriteDTO;
+import com.pixelocura.bitscafe.service.AdminFavoriteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AdminFavoriteControllerUnitTest {
+
+    @Mock
+    private AdminFavoriteService favoriteService;
+
+    @InjectMocks
+    private AdminFavoriteController favoriteController;
+
+    private UUID userId;
+    private UUID gameId;
+    private FavoriteDTO sampleFavorite;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userId = UUID.randomUUID();
+        gameId = UUID.randomUUID();
+
+        sampleFavorite = new FavoriteDTO();
+        sampleFavorite.setUserId(userId);
+        sampleFavorite.setGameId(gameId);
+    }
+
+    @Test
+    @DisplayName("CP01 - Agregar juego a favoritos")
+    void addFavorite_returnsOkMessage() {
+        // Act
+        ResponseEntity<?> response = favoriteController.addFavorite(userId, sampleFavorite);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("Juego agregado a favoritos", response.getBody());
+
+        // Verifica que el servicio fue llamado con el DTO correcto (con el userId asignado)
+        verify(favoriteService, times(1)).addFavorite(sampleFavorite);
+        assertEquals(userId, sampleFavorite.getUserId());
+    }
+
+    @Test
+    @DisplayName("CP02 - Obtener juegos favoritos de un usuario")
+    void getFavorites_returnsListOfFavorites() {
+        // Arrange
+        when(favoriteService.getFavorites(userId)).thenReturn(List.of(sampleFavorite));
+
+        // Act
+        ResponseEntity<List<FavoriteDTO>> response = favoriteController.getFavorites(userId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals(gameId, response.getBody().get(0).getGameId());
+
+        verify(favoriteService, times(1)).getFavorites(userId);
+    }
+
+    @Test
+    @DisplayName("CP03 - Eliminar juego de favoritos")
+    void deleteFavorite_returnsOkMessage() {
+        // Act
+        ResponseEntity<?> response = favoriteController.deleteFavorite(userId, gameId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("Juego eliminado de favoritos", response.getBody());
+
+        verify(favoriteService, times(1)).removeFavorite(userId, gameId);
+    }
+}

--- a/src/test/java/com/pixelocura/bitscafe/controller/AdminTransactionServiceControllerUnitTest.java
+++ b/src/test/java/com/pixelocura/bitscafe/controller/AdminTransactionServiceControllerUnitTest.java
@@ -1,0 +1,192 @@
+package com.pixelocura.bitscafe.controller;
+import com.pixelocura.bitscafe.exception.BadRequestException;
+import com.pixelocura.bitscafe.dto.TransactionDTO;
+import com.pixelocura.bitscafe.dto.TransactionDetailDTO;
+import com.pixelocura.bitscafe.service.AdminTransactionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AdminTransactionServiceControllerUnitTest {
+
+    @Mock
+    private AdminTransactionService adminTransactionService;
+
+    @InjectMocks
+    private AdminTransactionController adminTransactionController;
+
+    private UUID transactionId;
+    private UUID userId;
+    private TransactionDTO sampleTransactionDTO;
+    private TransactionDetailDTO sampleTransactionDetailDTO;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        transactionId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+
+        sampleTransactionDetailDTO = new TransactionDetailDTO();
+        sampleTransactionDetailDTO.setTransactionId(transactionId);
+        sampleTransactionDetailDTO.setGameId(UUID.randomUUID());
+        sampleTransactionDetailDTO.setPrice(49.99);
+
+        sampleTransactionDTO = new TransactionDTO();
+        sampleTransactionDTO.setId(transactionId);
+        sampleTransactionDTO.setUserId(userId);
+        sampleTransactionDTO.setTotalPrice(49.99);
+        sampleTransactionDTO.setTransactionDate(ZonedDateTime.now());
+        sampleTransactionDTO.setDetails(Arrays.asList(sampleTransactionDetailDTO));
+    }
+
+    @Test
+    @DisplayName("CP01 - Obtener transacciones por usuario: con datos existentes")
+    void getTransactionsByUser_withExistingData_returnsOkAndList() {
+        when(adminTransactionService.getTransactionsByUser(userId)).thenReturn(List.of(sampleTransactionDTO));
+
+        ResponseEntity<List<TransactionDTO>> response = adminTransactionController.getTransactionsByUser(userId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals(transactionId, response.getBody().get(0).getId());
+        verify(adminTransactionService, times(1)).getTransactionsByUser(userId);
+    }
+
+    @Test
+    @DisplayName("CP02 - Obtener transacciones por usuario: sin datos")
+    void getTransactionsByUser_noData_returnsNoContent() {
+        when(adminTransactionService.getTransactionsByUser(userId)).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<TransactionDTO>> response = adminTransactionController.getTransactionsByUser(userId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(adminTransactionService, times(1)).getTransactionsByUser(userId);
+    }
+
+    @Test
+    @DisplayName("CP03 - Crear transacción: con datos válidos")
+    void createTransaction_validData_returnsOkAndCreatedTransaction() {
+        TransactionDTO transactionToCreate = new TransactionDTO();
+        transactionToCreate.setUserId(userId);
+        transactionToCreate.setTotalPrice(49.99);
+        transactionToCreate.setTransactionDate(ZonedDateTime.now());
+        transactionToCreate.setDetails(Arrays.asList(sampleTransactionDetailDTO));
+
+        when(adminTransactionService.createTransaction(any(TransactionDTO.class))).thenReturn(sampleTransactionDTO);
+
+        ResponseEntity<TransactionDTO> response = adminTransactionController.createTransaction(transactionToCreate);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(transactionId, response.getBody().getId());
+        assertEquals(userId, response.getBody().getUserId());
+        verify(adminTransactionService, times(1)).createTransaction(transactionToCreate);
+    }
+
+    @Test
+    @DisplayName("CP04 - Obtener transacción por ID: con datos existentes")
+    void getTransactionById_withExistingId_returnsOkAndTransaction() {
+        when(adminTransactionService.getTransactionById(transactionId)).thenReturn(sampleTransactionDTO);
+
+        ResponseEntity<TransactionDTO> response = adminTransactionController.getTransaction(transactionId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(transactionId, response.getBody().getId());
+        verify(adminTransactionService, times(1)).getTransactionById(transactionId);
+    }
+
+    @Test
+    @DisplayName("CP06 - Obtener detalles de transacción: con datos existentes")
+    void getTransactionDetails_withExistingData_returnsOkAndList() {
+        when(adminTransactionService.getTransactionDetails(transactionId)).thenReturn(List.of(sampleTransactionDetailDTO));
+
+        ResponseEntity<List<TransactionDetailDTO>> response = adminTransactionController.getTransactionDetails(transactionId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        verify(adminTransactionService, times(1)).getTransactionDetails(transactionId);
+    }
+
+    @Test
+    @DisplayName("CP07 - Obtener detalles de transacción: sin datos")
+    void getTransactionDetails_noData_returnsNoContent() {
+        when(adminTransactionService.getTransactionDetails(transactionId)).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<TransactionDetailDTO>> response = adminTransactionController.getTransactionDetails(transactionId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(adminTransactionService, times(1)).getTransactionDetails(transactionId);
+    }
+
+    @Test
+    @DisplayName("CP08 - Obtener todas las transacciones: con datos existentes")
+    void getAllTransactions_withExistingData_returnsOkAndList() {
+        when(adminTransactionService.getAllTransactions()).thenReturn(List.of(sampleTransactionDTO));
+
+        ResponseEntity<List<TransactionDTO>> response = adminTransactionController.getAllTransactions();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals(transactionId, response.getBody().get(0).getId());
+        verify(adminTransactionService, times(1)).getAllTransactions();
+    }
+
+    @Test
+    @DisplayName("CP09 - Obtener todas las transacciones: sin datos")
+    void getAllTransactions_noData_returnsOkAndEmptyList() {
+        when(adminTransactionService.getAllTransactions()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<TransactionDTO>> response = adminTransactionController.getAllTransactions();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isEmpty());
+        verify(adminTransactionService, times(1)).getAllTransactions();
+    }
+
+    @Test
+    @DisplayName("CP10 - Crear transacción: datos inválidos lanza BadRequestException")
+    void createTransaction_invalidData_throwsBadRequestException() {
+        TransactionDTO invalidTransaction = new TransactionDTO(); // faltan campos requeridos
+
+        when(adminTransactionService.createTransaction(any(TransactionDTO.class)))
+                .thenThrow(new BadRequestException("Datos inválidos para la transacción"));
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> adminTransactionController.createTransaction(invalidTransaction)
+        );
+
+        assertEquals("Datos inválidos para la transacción", exception.getMessage());
+        verify(adminTransactionService, times(1)).createTransaction(invalidTransaction);
+    }
+}

--- a/src/test/java/com/pixelocura/bitscafe/service/AdminFavoriteServiceUnitTest.java
+++ b/src/test/java/com/pixelocura/bitscafe/service/AdminFavoriteServiceUnitTest.java
@@ -1,0 +1,95 @@
+package com.pixelocura.bitscafe.service;
+
+import com.pixelocura.bitscafe.dto.FavoriteDTO;
+import com.pixelocura.bitscafe.model.entity.Favorite;
+import com.pixelocura.bitscafe.model.entity.Game;
+import com.pixelocura.bitscafe.model.entity.User;
+import com.pixelocura.bitscafe.repository.FavoriteRepository;
+import com.pixelocura.bitscafe.repository.GameRepository;
+import com.pixelocura.bitscafe.repository.UserRepository;
+import com.pixelocura.bitscafe.service.impl.AdminFavoriteServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AdminFavoriteServiceUnitTest {
+
+    @Mock
+    private FavoriteRepository favoriteRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private GameRepository gameRepository;
+
+    @InjectMocks
+    private AdminFavoriteServiceImpl adminFavoriteService;
+
+    private UUID userId;
+    private UUID gameId;
+    private FavoriteDTO favoriteDTO;
+    private User user;
+    private Game game;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userId = UUID.randomUUID();
+        gameId = UUID.randomUUID();
+
+        favoriteDTO = new FavoriteDTO();
+        favoriteDTO.setUserId(userId);
+        favoriteDTO.setGameId(gameId);
+
+        user = new User();
+        user.setId(userId);
+
+        game = new Game();
+        game.setId(gameId);
+    }
+
+    @Test
+    void addFavorite_newFavorite_savesFavorite() {
+        when(favoriteRepository.existsByUser_IdAndGame_Id(userId, gameId)).thenReturn(false);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        adminFavoriteService.addFavorite(favoriteDTO);
+
+        verify(favoriteRepository).save(any(Favorite.class));
+    }
+
+    @Test
+    void addFavorite_alreadyExists_doesNothing() {
+        when(favoriteRepository.existsByUser_IdAndGame_Id(userId, gameId)).thenReturn(true);
+
+        adminFavoriteService.addFavorite(favoriteDTO);
+
+        verify(favoriteRepository, never()).save(any());
+    }
+
+    @Test
+    void removeFavorite_callsRepositoryDelete() {
+        adminFavoriteService.removeFavorite(userId, gameId);
+        verify(favoriteRepository, times(1)).deleteByUser_IdAndGame_Id(userId, gameId);
+    }
+
+    @Test
+    void getFavorites_returnsMappedDTOs() {
+        Favorite favorite = new Favorite();
+        favorite.setUser(user);
+        favorite.setGame(game);
+
+        when(favoriteRepository.findByUser_Id(userId)).thenReturn(List.of(favorite));
+
+        var result = adminFavoriteService.getFavorites(userId);
+
+        assertEquals(1, result.size());
+        assertEquals(userId, result.get(0).getUserId());
+        assertEquals(gameId, result.get(0).getGameId());
+    }
+}

--- a/src/test/java/com/pixelocura/bitscafe/service/AdminTransactionServiceUnitTest.java
+++ b/src/test/java/com/pixelocura/bitscafe/service/AdminTransactionServiceUnitTest.java
@@ -1,0 +1,78 @@
+package com.pixelocura.bitscafe.service;
+
+import com.pixelocura.bitscafe.dto.TransactionDTO;
+import com.pixelocura.bitscafe.dto.TransactionDetailDTO;
+import com.pixelocura.bitscafe.mapper.TransactionMapper;
+import com.pixelocura.bitscafe.model.entity.Game;
+import com.pixelocura.bitscafe.model.entity.Transaction;
+import com.pixelocura.bitscafe.model.entity.TransactionDetail;
+import com.pixelocura.bitscafe.model.entity.User;
+import com.pixelocura.bitscafe.repository.GameRepository;
+import com.pixelocura.bitscafe.repository.TransactionDetailRepository;
+import com.pixelocura.bitscafe.repository.TransactionRepository;
+import com.pixelocura.bitscafe.repository.UserRepository;
+import com.pixelocura.bitscafe.service.impl.AdminTransactionServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AdminTransactionServiceImplTest {
+
+    private TransactionRepository transactionRepository;
+    private TransactionDetailRepository transactionDetailRepository;
+    private UserRepository userRepository;
+    private GameRepository gameRepository;
+    private AdminTransactionServiceImpl transactionService;
+
+    @BeforeEach
+    void setUp() {
+        transactionRepository = mock(TransactionRepository.class);
+        transactionDetailRepository = mock(TransactionDetailRepository.class);
+        userRepository = mock(UserRepository.class);
+        gameRepository = mock(GameRepository.class);
+
+        transactionService = new AdminTransactionServiceImpl(
+                transactionRepository,
+                transactionDetailRepository,
+                userRepository,
+                gameRepository
+        );
+    }
+
+    @Test
+    void createTransaction_shouldSaveTransactionCorrectly() {
+        UUID userId = UUID.randomUUID();
+        UUID gameId = UUID.randomUUID();
+
+        TransactionDetailDTO detailDTO = new TransactionDetailDTO();
+        detailDTO.setGameId(gameId);
+        detailDTO.setPrice(29.99);
+
+        TransactionDTO transactionDTO = new TransactionDTO();
+        transactionDTO.setUserId(userId);
+        transactionDTO.setDetails(List.of(detailDTO));
+
+        User user = new User();
+        user.setId(userId);
+
+        Game game = new Game();
+        game.setId(gameId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+        when(transactionRepository.save(any(Transaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TransactionDTO result = transactionService.createTransaction(transactionDTO);
+
+        assertNotNull(result);
+        verify(transactionRepository).save(any(Transaction.class));
+    }
+}


### PR DESCRIPTION
this PR adds comprehensive unit tests for the AdminTransactionServiceImpl class, including scenarios for transaction creation, retrieval, and detail listing.

Additionally, a global exception handler was implemented to centralize error handling across the application, improving maintainability and API consistency.

+ Adds unit tests for transaction creation, retrieval by user, and fetching transaction details
+ Mocks interactions with repositories (UserRepository, GameRepository, etc.)
+ Introduces a global exception handler using @ControllerAdvice
+ Ensures meaningful error responses for common runtime exceptions